### PR TITLE
Update plugin.pp

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -59,7 +59,7 @@ define jenkins::plugin (
   Boolean $enabled                  = true,
   String $digest_type               = 'sha1',
   Boolean $pin                      = false,
-  Array $download_options           = ['--http1.1'],
+#  Array $download_options           = ['--http1.1'],
 ) {
   include jenkins
 


### PR DESCRIPTION
--http1.1 is no longer supported with wget 1.21.3, thus the module will fail to download plugins on Debian 12.

